### PR TITLE
feat(webapp): add auth-aware routing and api layer

### DIFF
--- a/sc-webapp/package-lock.json
+++ b/sc-webapp/package-lock.json
@@ -17,9 +17,20 @@
         "@types/react-dom": "^18.3.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-router-dom": "^6.30.1",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@babel/core": "^7.25.7",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-optional-chaining": "^7.21.0",
+        "@babel/preset-env": "^7.25.7",
+        "@typescript-eslint/eslint-plugin": "^5.62.0",
+        "@typescript-eslint/parser": "^5.62.0",
+        "eslint": "^8.57.1",
+        "eslint-plugin-react": "^7.37.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3516,6 +3527,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -15955,6 +15975,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/sc-webapp/package.json
+++ b/sc-webapp/package.json
@@ -12,6 +12,7 @@
     "@types/react-dom": "^18.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/sc-webapp/src/App.css
+++ b/sc-webapp/src/App.css
@@ -1,38 +1,205 @@
-.App {
-  text-align: center;
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
+body {
+  margin: 0;
+  background: #f5f6f8;
+  color: #1f2933;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
+.app-shell {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+}
+
+.app-header {
+  background: #111827;
+  color: #f9fafb;
+  padding: 0.75rem 1.5rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+.app-nav {
+  display: flex;
   align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
+  justify-content: space-between;
+  gap: 1.5rem;
+  max-width: 960px;
+  margin: 0 auto;
 }
 
-.App-link {
-  color: #61dafb;
+.app-nav a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
 }
 
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
+.app-nav a:hover,
+.app-nav a:focus {
+  text-decoration: underline;
+}
+
+.logo {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.app-nav__links {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.link-button {
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+
+.link-button:hover,
+.link-button:focus {
+  text-decoration: underline;
+}
+
+.app-content {
+  flex: 1;
+  max-width: 960px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+  box-sizing: border-box;
+}
+
+.auth-page,
+.feed-page,
+.profile-page {
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
+  padding: 2rem;
+}
+
+.auth-page h1,
+.feed-page h1,
+.profile-page h1 {
+  margin-top: 0;
+}
+
+.auth-form,
+.profile-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.auth-form label,
+.profile-form label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+  gap: 0.35rem;
+}
+
+.auth-form input,
+.profile-form input,
+.profile-form textarea,
+.feed-form textarea {
+  padding: 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #cbd2d9;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.feed-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+button {
+  background: #2563eb;
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:disabled {
+  background: #93c5fd;
+  cursor: not-allowed;
+}
+
+button:not(:disabled):hover,
+button:not(:disabled):focus {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.35);
+}
+
+.form-error {
+  color: #d14343;
+  margin: 0;
+}
+
+.form-success {
+  color: #0f9d58;
+  margin: 0;
+}
+
+.feed-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.feed-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.feed-item {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1rem;
+  background: #f9fafb;
+}
+
+.feed-item header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.feed-item time {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+@media (max-width: 640px) {
+  .app-nav {
+    flex-direction: column;
+    align-items: flex-start;
   }
-  to {
-    transform: rotate(360deg);
+
+  .app-content {
+    padding: 1.5rem 1rem;
   }
 }

--- a/sc-webapp/src/App.tsx
+++ b/sc-webapp/src/App.tsx
@@ -1,26 +1,38 @@
 import React from 'react';
-import logo from './logo.svg';
-import './App.css';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import Layout from './components/Layout';
+import ProtectedRoute from './components/ProtectedRoute';
+import FeedPage from './pages/FeedPage';
+import LoginPage from './pages/LoginPage';
+import ProfilePage from './pages/ProfilePage';
+import RegisterPage from './pages/RegisterPage';
 
-function App() {
+const App: React.FC = () => {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <Layout>
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <ProtectedRoute>
+              <FeedPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/profile"
+          element={
+            <ProtectedRoute>
+              <ProfilePage />
+            </ProtectedRoute>
+          }
+        />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </Layout>
   );
-}
+};
 
 export default App;

--- a/sc-webapp/src/api/auth.ts
+++ b/sc-webapp/src/api/auth.ts
@@ -1,0 +1,44 @@
+import { httpRequest } from './httpClient';
+
+export interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+export interface RegisterPayload {
+  name: string;
+  email: string;
+  password: string;
+}
+
+export interface AuthResponse<TUser = AuthUser> {
+  accessToken: string;
+  refreshToken?: string;
+  user: TUser;
+}
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  name: string;
+  bio?: string;
+  avatarUrl?: string;
+}
+
+export const authApi = {
+  login: (payload: LoginPayload) =>
+    httpRequest<AuthResponse>('/auth/login', {
+      method: 'POST',
+      body: payload,
+    }),
+  register: (payload: RegisterPayload) =>
+    httpRequest<AuthResponse>('/auth/register', {
+      method: 'POST',
+      body: payload,
+    }),
+  refresh: (token: string) =>
+    httpRequest<AuthResponse>('/auth/refresh', {
+      method: 'POST',
+      authToken: token,
+    }),
+};

--- a/sc-webapp/src/api/httpClient.ts
+++ b/sc-webapp/src/api/httpClient.ts
@@ -1,0 +1,81 @@
+const API_BASE_URL = process.env.REACT_APP_API_URL ?? 'http://localhost:8080';
+
+export interface HttpRequestOptions
+  extends Omit<RequestInit, 'body' | 'headers'> {
+  authToken?: string | null;
+  parseJson?: boolean;
+  body?: RequestInit['body'] | null | object;
+  headers?: HeadersInit;
+}
+
+export interface HttpErrorPayload {
+  message?: string;
+  [key: string]: unknown;
+}
+
+export class HttpError extends Error {
+  public status: number;
+  public payload?: HttpErrorPayload;
+
+  constructor(status: number, message: string, payload?: HttpErrorPayload) {
+    super(message);
+    this.status = status;
+    this.payload = payload;
+  }
+}
+
+const resolveUrl = (path: string): string => {
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return path;
+  }
+
+  if (!path.startsWith('/')) {
+    return `${API_BASE_URL}/${path}`;
+  }
+
+  return `${API_BASE_URL}${path}`;
+};
+
+export async function httpRequest<T>(
+  path: string,
+  options: HttpRequestOptions = {}
+): Promise<T> {
+  const { authToken, parseJson = true, headers, body, ...rest } = options;
+  const requestHeaders = new Headers(headers);
+
+  if (authToken) {
+    requestHeaders.set('Authorization', `Bearer ${authToken}`);
+  }
+
+  const hasJsonBody = body && !(body instanceof FormData) && typeof body === 'object';
+  if (hasJsonBody) {
+    requestHeaders.set('Content-Type', 'application/json');
+  }
+
+  const response = await fetch(resolveUrl(path), {
+    ...rest,
+    body: hasJsonBody ? JSON.stringify(body) : body ?? undefined,
+    headers: requestHeaders,
+    mode: 'cors',
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    let payload: HttpErrorPayload | undefined;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      // Ignore JSON parsing issues for error payloads.
+    }
+
+    const message =
+      payload?.message ?? response.statusText ?? 'Unexpected server error';
+    throw new HttpError(response.status, message, payload);
+  }
+
+  if (response.status === 204 || !parseJson) {
+    return undefined as unknown as T;
+  }
+
+  return (await response.json()) as T;
+}

--- a/sc-webapp/src/api/posts.ts
+++ b/sc-webapp/src/api/posts.ts
@@ -1,0 +1,27 @@
+import { httpRequest } from './httpClient';
+
+export interface Post {
+  id: string;
+  authorId: string;
+  authorName: string;
+  content: string;
+  createdAt: string;
+}
+
+export interface CreatePostPayload {
+  content: string;
+}
+
+export const postsApi = {
+  getFeed: (token: string | null) =>
+    httpRequest<Post[]>('/posts', {
+      method: 'GET',
+      authToken: token ?? undefined,
+    }),
+  create: (token: string, payload: CreatePostPayload) =>
+    httpRequest<Post>('/posts', {
+      method: 'POST',
+      authToken: token,
+      body: payload,
+    }),
+};

--- a/sc-webapp/src/api/users.ts
+++ b/sc-webapp/src/api/users.ts
@@ -1,0 +1,26 @@
+import { httpRequest } from './httpClient';
+import type { AuthUser } from './auth';
+
+export interface UpdateProfilePayload {
+  name?: string;
+  bio?: string;
+}
+
+export interface Profile extends AuthUser {
+  bio?: string;
+  avatarUrl?: string;
+}
+
+export const usersApi = {
+  getCurrent: (token: string) =>
+    httpRequest<Profile>('/users/me', {
+      method: 'GET',
+      authToken: token,
+    }),
+  updateProfile: (token: string, payload: UpdateProfilePayload) =>
+    httpRequest<Profile>('/users/me', {
+      method: 'PUT',
+      authToken: token,
+      body: payload,
+    }),
+};

--- a/sc-webapp/src/components/Layout.tsx
+++ b/sc-webapp/src/components/Layout.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useAuthContext } from '../context/AuthContext';
+
+export const Layout: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const { user, logout } = useAuthContext();
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <nav className="app-nav">
+          <Link to="/" className="logo">
+            SoulConnect
+          </Link>
+          <div className="app-nav__links">
+            {user ? (
+              <>
+                <Link to="/">Лента</Link>
+                <Link to="/profile">Профиль</Link>
+                <button type="button" onClick={logout} className="link-button">
+                  Выйти
+                </button>
+              </>
+            ) : (
+              <>
+                <Link to="/login">Войти</Link>
+                <Link to="/register">Регистрация</Link>
+              </>
+            )}
+          </div>
+        </nav>
+      </header>
+      <main className="app-content">{children}</main>
+    </div>
+  );
+};
+
+export default Layout;

--- a/sc-webapp/src/components/ProtectedRoute.tsx
+++ b/sc-webapp/src/components/ProtectedRoute.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuthContext } from '../context/AuthContext';
+
+interface ProtectedRouteProps {
+  children: React.ReactElement;
+}
+
+export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+  const { user, isLoading } = useAuthContext();
+  const location = useLocation();
+
+  if (isLoading) {
+    return <p>Загрузка...</p>;
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;

--- a/sc-webapp/src/context/AuthContext.tsx
+++ b/sc-webapp/src/context/AuthContext.tsx
@@ -1,0 +1,135 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { authApi, type AuthResponse, type AuthUser } from '../api/auth';
+import { usersApi } from '../api/users';
+
+export interface AuthState {
+  user: AuthUser | null;
+  token: string | null;
+  isLoading: boolean;
+}
+
+export interface AuthContextValue extends AuthState {
+  login: (email: string, password: string) => Promise<void>;
+  register: (name: string, email: string, password: string) => Promise<void>;
+  logout: () => void;
+  refreshUser: () => Promise<void>;
+}
+
+const TOKEN_STORAGE_KEY = 'sc-webapp/token';
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const persistAuth = (auth: Pick<AuthResponse, 'accessToken' | 'refreshToken'>) => {
+  localStorage.setItem(
+    TOKEN_STORAGE_KEY,
+    JSON.stringify({
+      accessToken: auth.accessToken,
+      refreshToken: auth.refreshToken,
+    })
+  );
+};
+
+const restoreToken = (): { accessToken: string; refreshToken?: string } | null => {
+  try {
+    const serialized = localStorage.getItem(TOKEN_STORAGE_KEY);
+    return serialized ? JSON.parse(serialized) : null;
+  } catch (error) {
+    console.warn('Unable to restore auth token from storage', error);
+    return null;
+  }
+};
+
+const clearPersistedAuth = () => {
+  localStorage.removeItem(TOKEN_STORAGE_KEY);
+};
+
+export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const bootstrap = useCallback(async () => {
+    const stored = restoreToken();
+    if (!stored?.accessToken) {
+      setIsLoading(false);
+      return;
+    }
+
+    setToken(stored.accessToken);
+    try {
+      const profile = await usersApi.getCurrent(stored.accessToken);
+      setUser(profile);
+    } catch (error) {
+      console.error('Failed to load current user profile', error);
+      clearPersistedAuth();
+      setToken(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void bootstrap();
+  }, [bootstrap]);
+
+  const handleAuthSuccess = useCallback(async (response: AuthResponse) => {
+    persistAuth(response);
+    setToken(response.accessToken);
+    setUser(response.user);
+  }, []);
+
+  const login = useCallback(async (email: string, password: string) => {
+    const response = await authApi.login({ email, password });
+    await handleAuthSuccess(response);
+  }, [handleAuthSuccess]);
+
+  const register = useCallback(
+    async (name: string, email: string, password: string) => {
+      const response = await authApi.register({ name, email, password });
+      await handleAuthSuccess(response);
+    },
+    [handleAuthSuccess]
+  );
+
+  const refreshUser = useCallback(async () => {
+    if (!token) {
+      return;
+    }
+
+    try {
+      const profile = await usersApi.getCurrent(token);
+      setUser(profile);
+    } catch (error) {
+      console.error('Failed to refresh profile', error);
+    }
+  }, [token]);
+
+  const logout = useCallback(() => {
+    clearPersistedAuth();
+    setToken(null);
+    setUser(null);
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ user, token, isLoading, login, register, logout, refreshUser }),
+    [user, token, isLoading, login, register, logout, refreshUser]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuthContext = (): AuthContextValue => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuthContext must be used within AuthProvider');
+  }
+
+  return context;
+};

--- a/sc-webapp/src/index.tsx
+++ b/sc-webapp/src/index.tsx
@@ -1,15 +1,21 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { AuthProvider } from './context/AuthContext';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
   </React.StrictMode>
 );
 

--- a/sc-webapp/src/pages/FeedPage.tsx
+++ b/sc-webapp/src/pages/FeedPage.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useState } from 'react';
+import { postsApi, type Post } from '../api/posts';
+import { HttpError } from '../api/httpClient';
+import { useAuthContext } from '../context/AuthContext';
+
+export const FeedPage: React.FC = () => {
+  const { token, user } = useAuthContext();
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [newPost, setNewPost] = useState('');
+  const [isPublishing, setIsPublishing] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      return;
+    }
+
+    const fetchPosts = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const data = await postsApi.getFeed(token);
+        setPosts(data);
+      } catch (err) {
+        if (err instanceof HttpError) {
+          setError(err.message);
+        } else if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError('Не удалось загрузить ленту');
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void fetchPosts();
+  }, [token]);
+
+  const handleCreatePost = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!token || !newPost.trim()) {
+      return;
+    }
+
+    setIsPublishing(true);
+    try {
+      const created = await postsApi.create(token, { content: newPost.trim() });
+      setPosts((prev) => [created, ...prev]);
+      setNewPost('');
+    } catch (err) {
+      if (err instanceof HttpError) {
+        setError(err.message);
+      } else if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('Не удалось опубликовать пост');
+      }
+    } finally {
+      setIsPublishing(false);
+    }
+  };
+
+  return (
+    <section className="feed-page">
+      <header className="feed-header">
+        <h1>Лента</h1>
+        {user ? <p>Добро пожаловать, {user.name}!</p> : null}
+      </header>
+
+      <form className="feed-form" onSubmit={handleCreatePost}>
+        <textarea
+          placeholder="Поделитесь своими мыслями..."
+          value={newPost}
+          onChange={(event) => setNewPost(event.target.value)}
+          rows={3}
+          disabled={!token || isPublishing}
+        />
+        <button type="submit" disabled={!newPost.trim() || isPublishing}>
+          {isPublishing ? 'Публикация...' : 'Опубликовать'}
+        </button>
+      </form>
+
+      {isLoading ? <p>Загрузка ленты...</p> : null}
+      {error ? <p className="form-error">{error}</p> : null}
+
+      <ul className="feed-list">
+        {posts.map((post) => (
+          <li key={post.id} className="feed-item">
+            <header>
+              <strong>{post.authorName}</strong>
+              <time dateTime={post.createdAt}>
+                {new Date(post.createdAt).toLocaleString()}
+              </time>
+            </header>
+            <p>{post.content}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default FeedPage;

--- a/sc-webapp/src/pages/LoginPage.tsx
+++ b/sc-webapp/src/pages/LoginPage.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { HttpError } from '../api/httpClient';
+import { useAuthContext } from '../context/AuthContext';
+
+export const LoginPage: React.FC = () => {
+  const { login, user } = useAuthContext();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await login(email, password);
+      const redirectPath = (location.state as { from?: Location })?.from?.pathname;
+      navigate(redirectPath ?? '/', { replace: true });
+    } catch (err) {
+      if (err instanceof HttpError) {
+        setError(err.message);
+      } else if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('Не удалось выполнить вход');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (user) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <section className="auth-page">
+      <h1>Вход</h1>
+      <form className="auth-form" onSubmit={handleSubmit}>
+        <label>
+          Email
+          <input
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+            autoComplete="email"
+          />
+        </label>
+        <label>
+          Пароль
+          <input
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+            autoComplete="current-password"
+          />
+        </label>
+        {error ? <p className="form-error">{error}</p> : null}
+        <button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Входим...' : 'Войти'}
+        </button>
+      </form>
+      <p>
+        Нет аккаунта? <Link to="/register">Создайте его</Link>.
+      </p>
+    </section>
+  );
+};
+
+export default LoginPage;

--- a/sc-webapp/src/pages/ProfilePage.tsx
+++ b/sc-webapp/src/pages/ProfilePage.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { HttpError } from '../api/httpClient';
+import { usersApi } from '../api/users';
+import { useAuthContext } from '../context/AuthContext';
+
+export const ProfilePage: React.FC = () => {
+  const { user, token, refreshUser } = useAuthContext();
+  const [bio, setBio] = useState(user?.bio ?? '');
+  const [name, setName] = useState(user?.name ?? '');
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setBio(user?.bio ?? '');
+    setName(user?.name ?? '');
+  }, [user]);
+
+  if (!user || !token) {
+    return null;
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setMessage(null);
+    setIsSaving(true);
+
+    try {
+      await usersApi.updateProfile(token, { name, bio });
+      await refreshUser();
+      setMessage('Профиль обновлён');
+    } catch (err) {
+      if (err instanceof HttpError) {
+        setError(err.message);
+      } else if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('Не удалось обновить профиль');
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <section className="profile-page">
+      <h1>Профиль</h1>
+      <form className="profile-form" onSubmit={handleSubmit}>
+        <label>
+          Email
+          <input type="email" value={user.email} disabled />
+        </label>
+        <label>
+          Имя
+          <input
+            type="text"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            required
+          />
+        </label>
+        <label>
+          О себе
+          <textarea
+            value={bio}
+            onChange={(event) => setBio(event.target.value)}
+            rows={4}
+            placeholder="Расскажите о себе"
+          />
+        </label>
+        {error ? <p className="form-error">{error}</p> : null}
+        {message ? <p className="form-success">{message}</p> : null}
+        <button type="submit" disabled={isSaving}>
+          {isSaving ? 'Сохраняем...' : 'Сохранить изменения'}
+        </button>
+      </form>
+    </section>
+  );
+};
+
+export default ProfilePage;

--- a/sc-webapp/src/pages/RegisterPage.tsx
+++ b/sc-webapp/src/pages/RegisterPage.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import { Link, Navigate, useNavigate } from 'react-router-dom';
+import { HttpError } from '../api/httpClient';
+import { useAuthContext } from '../context/AuthContext';
+
+export const RegisterPage: React.FC = () => {
+  const { register, user } = useAuthContext();
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await register(name, email, password);
+      navigate('/', { replace: true });
+    } catch (err) {
+      if (err instanceof HttpError) {
+        setError(err.message);
+      } else if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('Не удалось завершить регистрацию');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (user) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <section className="auth-page">
+      <h1>Регистрация</h1>
+      <form className="auth-form" onSubmit={handleSubmit}>
+        <label>
+          Имя
+          <input
+            type="text"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            required
+            autoComplete="name"
+          />
+        </label>
+        <label>
+          Email
+          <input
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+            autoComplete="email"
+          />
+        </label>
+        <label>
+          Пароль
+          <input
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+            autoComplete="new-password"
+            minLength={6}
+          />
+        </label>
+        {error ? <p className="form-error">{error}</p> : null}
+        <button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Создаём...' : 'Зарегистрироваться'}
+        </button>
+      </form>
+      <p>
+        Уже есть аккаунт? <Link to="/login">Войдите</Link>.
+      </p>
+    </section>
+  );
+};
+
+export default RegisterPage;


### PR DESCRIPTION
## Summary
- add client-side routing for feed, profile, login and registration views with protected access
- introduce shared auth context with persisted tokens and REST gateway integration for auth, users and posts
- style layout and screens to support the new navigation experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da7ccb41a08329b248bc0ab1122935