### PR TITLE
Fix gRPC auth port mapstructure tag

### DIFF
--- a/sc-api-getaway/internal/config/config.go
+++ b/sc-api-getaway/internal/config/config.go
@@ -10,7 +10,7 @@ type Config struct {
 	EnvType       string `mapstructure:"ENV_TYPE"`
 	ServerPort    string `mapstructure:"SERVER_PORT"`
 	DBSource      string `mapstructure:"DB_SOURCE"`
-	GrpcAuthPort  string `mapstructure:"GPRC_AUTH_PORT"`
+	GrpcAuthPort  string `mapstructure:"GRPC_AUTH_PORT"`
 	WebappBaseUrl string `mapstructure:"WEBAPP_BASE_URL"`
 }
 


### PR DESCRIPTION
## Summary
- correct the API gateway configuration to load the GRPC auth port from the properly named environment variable

## Testing
- go test ./... *(fails: hangs waiting for external dependencies, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68da7ccfb69c8329b4397538f860b710