### PR TITLE
Add multi-stage Docker build for sc-user service

### DIFF
--- a/sc-user/Dockerfile
+++ b/sc-user/Dockerfile
@@ -1,4 +1,32 @@
-FROM ubuntu:latest
-LABEL authors="karadyauran"
+# syntax=docker/dockerfile:1
 
-ENTRYPOINT ["top", "-b"]
+FROM golang:1.23-alpine AS builder
+WORKDIR /app
+
+# Download module dependencies first to leverage caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy only the service source needed for the build
+COPY sc-user ./sc-user
+
+# Build the service binary
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /build/general ./sc-user/cmd/general
+
+# Build the migrate CLI with postgres support
+RUN GOBIN=/build go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+
+FROM alpine:3.20
+WORKDIR /app
+
+RUN apk add --no-cache ca-certificates
+
+# Copy binaries and application files
+COPY --from=builder /build/general /usr/local/bin/general
+COPY --from=builder /build/migrate /usr/local/bin/migrate
+COPY sc-user/internal/db/migration ./internal/db/migration
+COPY sc-user/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- replace the sc-user Dockerfile with a multi-stage build that compiles the service binary and migrate CLI before copying only the runtime artifacts into an Alpine image
- update the entrypoint script to run migrations using the DB_SOURCE environment variable before starting the compiled binary

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da8e6b1c588329a04c67ed5efb2217