### PR TITLE
Fix missing semicolon in user migration

### DIFF
--- a/sc-user/internal/db/migration/000101_user_schema.up.sql
+++ b/sc-user/internal/db/migration/000101_user_schema.up.sql
@@ -23,4 +23,4 @@ CREATE TABLE IF NOT EXISTS subscriptions (
 CREATE OR REPLACE TRIGGER update_users_timestamp
     BEFORE UPDATE ON users
     FOR EACH ROW
-    EXECUTE FUNCTION update_timestamp()
+    EXECUTE FUNCTION update_timestamp();


### PR DESCRIPTION
## Summary
- add the missing semicolon to the `update_users_timestamp` trigger in the user schema migration

## Testing
- /usr/local/bin/migrate -path sc-user/internal/db/migration -database "postgresql://root:secret@localhost:5432/sc_db?sslmode=disable" -verbose up

------
https://chatgpt.com/codex/tasks/task_e_68dbae6c59948329a61ddeeb8c1ff703